### PR TITLE
fix MYSQL_UNIX_PORT variable not set because of pipe process env (tes…

### DIFF
--- a/db_smart_backup.sh
+++ b/db_smart_backup.sh
@@ -1077,12 +1077,13 @@ mysql_set_connection_vars() {
     export MYSQL_TCP_PORT="${PORT:-3306}"
     export MYSQL_PWD="${PASSWORD}"
     if [ x"${MYSQL_HOST}" = "xlocalhost" ];then
-        echo -e "$MYSQL_SOCK_PATHS"|\
-            while read path
-            do
-                export MYSQL_HOST="127.0.0.1"
-                export MYSQL_UNIX_PORT="${path}"
-            done
+        mkfifo tmppipe
+        echo -e "$MYSQL_SOCK_PATHS" > tmppipe &
+        while read path
+        do
+            export MYSQL_HOST="127.0.0.1"
+            export MYSQL_UNIX_PORT="${path}"
+        done < tmppipe
     fi
     if [ -e "${MYSQL_UNIX_PORT}" ];then
         log "Using mysql socket: ${path}"


### PR DESCRIPTION
…ted on Centos6.7)

http://mywiki.wooledge.org/BashFAQ/024
"I set variables in a loop that's in a pipeline. Why do they disappear after the loop terminates? Or, why can't I pipe data to read?"
-> because the pipeline+while is a process in another scope.
On the solutions I've tested the mkfifo and it fixed my env.

My env: Centos 6.7
MYSQl_SOCK_PATHS="/srv/data/mysql/mysql.sock"